### PR TITLE
feat: support for ...rest parameters

### DIFF
--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -13,6 +13,7 @@ export const F_INTERFACE: 'I' = 'I';
 export const F_FUNCTION: 'F' = 'F';
 export const F_ARROW_FUNCTION: '>' = '>';
 export const F_OPTIONAL: '?' = '?';
+export const F_REST: '3' = '3';
 export const F_ASYNC: 'a' = 'a';
 export const F_EXPORTED: 'e' = 'e';
 export const F_INFERRED: '.' = '.';

--- a/src/lib/reflect.test.ts
+++ b/src/lib/reflect.test.ts
@@ -356,6 +356,17 @@ describe('ReflectedMethod', it => {
         expect(ReflectedFunction.new(A).isAsync).to.be.false;
         expect(ReflectedFunction.new(B).isAsync).to.be.true;
     });
+    it('reflects function variadic', () => {
+        function A() { }
+
+        Reflect.defineMetadata('rt:f', `${format.F_FUNCTION}`, A);
+        Reflect.defineMetadata('rt:p', [], A);
+        function B() { }
+        Reflect.defineMetadata('rt:f', `${format.F_METHOD}`, B);
+        Reflect.defineMetadata('rt:p', [{ n: 'a', t: () => String }, { n: 'b', t: () => Boolean, f: `${format.F_REST}` }], B);
+        expect(ReflectedFunction.new(A).isVariadic).to.be.false;
+        expect(ReflectedFunction.new(B).isVariadic).to.be.true;
+    });
     it('reflects static method names without metadata', () => {
         class B {
             static foo() { }
@@ -411,6 +422,30 @@ describe('ReflectedMethod', it => {
         expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').flags.isOptional).to.be.true;
         expect(ReflectedClass.new(B).getMethod('foo').parameters[1].isOptional).to.be.true;
         expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').isOptional).to.be.true;
+    });
+    it('reflects parameter rest', () => {
+        class B { }
+        Reflect.defineMetadata('rt:f', `${format.F_METHOD}`, B.prototype, 'foo');
+        Reflect.defineMetadata('rt:p', [{ n: 'a', t: () => String }, { n: 'b', t: () => Boolean, f: `${format.F_REST}` }], B.prototype, 'foo');
+        Reflect.defineMetadata('rt:m', ['foo', 'bar'], B);
+
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].name).to.equal('a');
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').name).to.equal('a');
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').flags.isRest).to.be.false;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].flags.isRest).to.be.false;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].isRest).to.be.false;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').isRest).to.be.false;
+
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].name).to.equal('b');
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').name).to.equal('b');
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].flags.isRest).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').flags.isRest).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].isRest).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').isRest).to.be.true;
     });
 });
 

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -913,6 +913,7 @@ export class ReflectedFlags {
     @Flag(format.F_CLASS) isClass: boolean;
     @Flag(format.F_INTERFACE) isInterface: boolean;
     @Flag(format.F_OPTIONAL) isOptional: boolean;
+    @Flag(format.F_REST) isRest: boolean;
     @Flag(format.F_ASYNC) isAsync: boolean;
     @Flag(format.F_EXPORTED) isExported: boolean;
     @Flag(format.F_INFERRED) isInferred: boolean;
@@ -972,6 +973,13 @@ export class ReflectedParameter<ValueT = any> {
      */
     get isOptional() {
         return this.flags.isOptional;
+    }
+
+    /**
+     * True if this parameter is a rest parameter
+     */
+    get isRest() {
+        return this.flags.isRest;
     }
 
     /**
@@ -1450,6 +1458,13 @@ export class ReflectedFunction<T extends Function = Function> implements Reflect
      */
     get isAsync() {
         return this.flags.isAsync;
+    }
+
+    /**
+     * True if this function is a variadic function.
+     */
+    get isVariadic() {
+        return this.parameters.find(v => v.isRest) !== undefined;
     }
 }
 

--- a/src/transformer/encode-parameter.ts
+++ b/src/transformer/encode-parameter.ts
@@ -24,6 +24,9 @@ export function encodeParameter(encoder: TypeEncoderImpl, param: ts.ParameterDec
     if (param.questionToken)
         f.push(format.F_OPTIONAL);
 
+    if (param.dotDotDotToken)
+        f.push(format.F_REST);
+
     let typeExpr = param.type
         ? encoder.referToTypeNode(param.type)
         : encoder.referToType(checker.getTypeAtLocation(param.initializer), param.type)

--- a/src/transformer/tests/metadata.test.ts
+++ b/src/transformer/tests/metadata.test.ts
@@ -701,6 +701,39 @@ describe('rt:p', it => {
         let params = Reflect.getMetadata('rt:p', exports.C);
         expect(params[0].f).to.contain(F_REST);
     });
+    it('emits F_REST for rest method', async () => {
+        let exports = await runSimple({
+            code: `
+                export class C {
+                    test(a,...rest){}
+                }
+            `
+        });
+
+        let params = Reflect.getMetadata('rt:p', exports.C.prototype,"test");
+        expect(params[0].f).to.be.undefined;
+        expect(params[1].f).to.contain(F_REST);
+    });
+    it('emits F_REST for functions', async () => {
+        let exports = await runSimple({
+            code: `
+            export function test(a,...rest){}
+            export function test2(...b){}
+            export const test3 = (a,...c)=>{}
+            `
+        });
+
+        let params = Reflect.getMetadata('rt:p', exports.test);
+        expect(params[0].f).to.be.undefined;
+        expect(params[1].f).to.contain(F_REST);
+
+        params = Reflect.getMetadata('rt:p', exports.test2);
+        expect(params[0].f).to.contain(F_REST);
+
+        params = Reflect.getMetadata('rt:p', exports.test3);
+        expect(params[0].f).to.be.undefined;
+        expect(params[1].f).to.contain(F_REST);
+    });
     it('emits multiple flags for ctor param', async () => {
         let exports = await runSimple({
             code: `

--- a/src/transformer/tests/metadata.test.ts
+++ b/src/transformer/tests/metadata.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describe } from 'razmin';
 import ts from 'typescript';
 import {
-    F_OPTIONAL, F_PRIVATE, F_PROTECTED, F_PUBLIC, F_READONLY, F_INFERRED, F_ABSTRACT, F_ARROW_FUNCTION,
+    F_REST, F_OPTIONAL, F_PRIVATE, F_PROTECTED, F_PUBLIC, F_READONLY, F_INFERRED, F_ABSTRACT, F_ARROW_FUNCTION,
     F_ASYNC, F_CLASS, F_EXPORTED, F_FUNCTION, F_INTERFACE, F_METHOD, F_STATIC, T_ANY, T_ARRAY, T_FALSE,
     T_GENERIC, T_INTERSECTION, T_MAPPED, T_NULL, T_THIS, T_TRUE, T_TUPLE, T_UNDEFINED, T_UNION, T_UNKNOWN,
     T_OBJECT, T_VOID, T_ENUM, T_FUNCTION, InterfaceToken, RtObjectMember, RtObjectType, RtFunctionType,
@@ -686,6 +686,20 @@ describe('rt:p', it => {
 
         let params = Reflect.getMetadata('rt:p', exports.C);
         expect(params[0].f).to.contain(F_OPTIONAL);
+    });
+    it('emits F_REST for rest ctor param', async () => {
+        let exports = await runSimple({
+            code: `
+                export class A { }
+                export class B { }
+                export class C {
+                    constructor(...hello : A[]) { }
+                }
+            `
+        });
+
+        let params = Reflect.getMetadata('rt:p', exports.C);
+        expect(params[0].f).to.contain(F_REST);
     });
     it('emits multiple flags for ctor param', async () => {
         let exports = await runSimple({


### PR DESCRIPTION
param.isRest -> return true if the param is a rest parameter
funct.isVariadic -> return true if the function is a variadic function